### PR TITLE
`$PATH` variable search

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "(gdb) Launch",
       "type": "cppdbg",
       "request": "launch",
-      "program": "./msh",
+      "program": "${workspaceFolder}/build/msh",
       "cwd": "${workspaceFolder}/build",
       "MIMode": "gdb",
       "setupCommands": [

--- a/include/cmd.h
+++ b/include/cmd.h
@@ -5,5 +5,5 @@ typedef struct cmd_t Commandline;
 Commandline *cmd_init();
 void cmd_free(Commandline *arg);
 int read_line(Commandline *cmdline);
-char *search_executable(const char *executable);
+char *search_executable(Commandline *cmdline, const char *executable);
 void process_arg(Commandline *cmdline, char **executable);

--- a/include/cmd.h
+++ b/include/cmd.h
@@ -5,4 +5,5 @@ typedef struct cmd_t Commandline;
 Commandline *cmd_init();
 void cmd_free(Commandline *arg);
 int read_line(Commandline *cmdline);
-char *get_arg(Commandline *cmdline);
+char *search_executable(const char *executable);
+void process_arg(Commandline *cmdline, char **executable);

--- a/include/cmd.h
+++ b/include/cmd.h
@@ -4,5 +4,5 @@ typedef struct cmd_t Commandline;
 
 Commandline *cmd_init();
 void cmd_free(Commandline *arg);
-void read_line(Commandline *cmdline);
+int read_line(Commandline *cmdline);
 char *get_arg(Commandline *cmdline);

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,4 @@
+// Configuration
+// ------------------
+// Input Buffer Length
+#define IBUF_LEN 256

--- a/include/path.h
+++ b/include/path.h
@@ -1,1 +1,1 @@
-char *get_path();
+char **init_path(void);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -46,15 +46,16 @@ void cmd_free(Commandline *cmdline)
   free(cmdline);
 }
 
-void read_line(Commandline *cmdline)
+int read_line(Commandline *cmdline)
 {
   if (!fgets(cmdline->buf, IBUF_LEN, stdin))
   {
     perror("unable to read to stdin");
-    return;
+    return 1;
   }
 
   cmdline->buf[strcspn(cmdline->buf, "\n")] = 0;
+  return 0;
 }
 
 char *get_arg(Commandline *cmdline)
@@ -62,13 +63,13 @@ char *get_arg(Commandline *cmdline)
   if (cmdline->tok == NULL)
   {
     cmdline->tok = strdup(cmdline->buf);
-    return strtok(cmdline->tok, IBUF_DENY);
-  }
 
-  if (cmdline->tok == NULL)
-  {
-    printf("error: token was empty for some reason\n");
-    return NULL;
+    if (!cmdline->tok)
+    {
+      return NULL;
+    }
+
+    return strtok(cmdline->tok, IBUF_DENY);
   }
 
   return strtok(NULL, IBUF_DENY);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 
 #include "path.h"
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 struct cmd_t
 {
@@ -50,7 +51,9 @@ int read_line(Commandline *cmdline)
 {
   if (!fgets(cmdline->buf, IBUF_LEN, stdin))
   {
-    perror("unable to read to stdin");
+    if (!feof(stdin))
+      perror("unable to read to stdin");
+
     return 1;
   }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -18,6 +18,7 @@ struct cmd_t
 {
   char *buf;
   char *tok;
+  char **bin_dirs;
 };
 
 Commandline *cmd_init()
@@ -37,6 +38,8 @@ Commandline *cmd_init()
     return NULL;
   }
 
+  args->bin_dirs = init_path();
+
   return args;
 }
 
@@ -46,6 +49,7 @@ void cmd_free(Commandline *cmdline)
     free(cmdline->tok);
 
   free(cmdline->buf);
+  free(cmdline->bin_dirs);
   free(cmdline);
 }
 
@@ -85,18 +89,20 @@ char *get_arg(Commandline *cmdline)
   return strtok(NULL, IBUF_DENY);
 }
 
-char *search_executable(const char *executable)
+char *search_executable(Commandline *cmdline, const char *executable)
 {
   char *path_dir = NULL;
 
   printf("Searching $PATH for `%s`\n", executable);
+  // FIXME: This shouldn't remain here, only for debugging purposes
+  int pathno = 0;
   do
   {
-    path_dir = get_path();
-    if (path_dir == NULL)
-      break;
+    printf("[%3d]", pathno);
+    path_dir = cmdline->bin_dirs[++pathno];
 
-    printf("\t%s\n", path_dir);
+    if (path_dir)
+      printf("\t%s\n", path_dir);
   } while (path_dir != NULL);
 
   // FIXME: This should return `executable`'s real path

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -57,6 +57,11 @@ int read_line(Commandline *cmdline)
     return 1;
   }
 
+  // After every line is read, whatever remains
+  // inside `tok` should be cleared
+  free(cmdline->tok);
+  cmdline->tok = NULL;
+
   cmdline->buf[strcspn(cmdline->buf, "\n")] = 0;
   return 0;
 }

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -12,6 +12,8 @@
 #include <string.h>
 #include <errno.h>
 
+#include "path.h"
+
 struct cmd_t
 {
   char *buf;
@@ -81,4 +83,44 @@ char *get_arg(Commandline *cmdline)
   }
 
   return strtok(NULL, IBUF_DENY);
+}
+
+char *search_executable(const char *executable)
+{
+  char *path_dir = NULL;
+
+  printf("Searching $PATH for `%s`\n", executable);
+  do
+  {
+    path_dir = get_path();
+    if (path_dir == NULL)
+      break;
+
+    printf("\t%s\n", path_dir);
+  } while (path_dir != NULL);
+
+  // FIXME: This should return `executable`'s real path
+  return NULL;
+}
+
+void process_arg(Commandline *cmdline, char **executable)
+{
+  char *current_arg = get_arg(cmdline);
+
+  *executable = current_arg;
+  if (current_arg == NULL)
+    return;
+
+  printf("Executable: %s\n", *executable);
+  for (int i = 0; current_arg != NULL; i++)
+  {
+    current_arg = get_arg(cmdline);
+
+    // Sometimes this becomes NULL
+    // as this loop is executing
+    if (current_arg == NULL)
+      break;
+
+    printf("\t%-3d: %s\n", i, current_arg);
+  }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@ int main()
     errno = 0;
     do
   {
+    errno = 0;
     printf("> ");
 
     if (read_line(cmdline))

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,8 @@ int main()
     exit(EXIT_FAILURE);
   }
 
-  do
+    errno = 0;
+    do
   {
     printf("> ");
 

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,7 @@ int main()
 
     process_arg(cmdline, &executable);
     if (executable != NULL)
-      executable = search_executable(executable);
+      executable = search_executable(cmdline, executable);
     if (errno)
     {
       perror("error while running");

--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,8 @@
+// Configuration
+// ------------------
+// Input Buffer Length
+#define IBUF_LEN 256
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -33,6 +38,11 @@ int main()
     for (int i = 0; current_arg != NULL; i++)
     {
       current_arg = get_arg(cmdline);
+
+      // Sometimes this becomes NULL
+      // as this loop is executing
+      if (current_arg == NULL)
+        break;
 
       printf("\t%-3d: %s\n", i, current_arg);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -7,13 +7,36 @@
 int main()
 {
   Commandline *cmdline = cmd_init();
-  char *current_arg, *curr_path = NULL;
+  char *executable, *current_arg;
 
   if (cmdline == NULL)
   {
     perror("failed to initialize tokenizer");
     exit(EXIT_FAILURE);
   }
+
+  do
+  {
+    printf("> ");
+
+    if (read_line(cmdline))
+    {
+      printf("\rexit\n");
+      break;
+    }
+
+    current_arg = get_arg(cmdline);
+    executable = current_arg;
+
+    // FIXME: This shit broken af :/
+    printf("Executable: %s\n", executable);
+    for (int i = 0; current_arg != NULL; i++)
+    {
+      current_arg = get_arg(cmdline);
+
+      printf("\t%-3d: %s\n", i, current_arg);
+    }
+  } while (1);
 
   cmd_free(cmdline);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -15,29 +15,5 @@ int main()
     exit(EXIT_FAILURE);
   }
 
-  printf("Enter text: ");
-  read_line(cmdline);
-
-  for (int i = 0; current_arg != NULL; i++)
-  {
-    current_arg = get_arg(cmdline);
-
-    if (current_arg == NULL)
-    {
-      break;
-    }
-
-    printf("[%d]:\t%s\n", i, current_arg);
-  }
-
-  printf("$PATH raw: %s\n", getenv("PATH"));
-  printf("$PATH dump:\n");
-  curr_path = get_path();
-  for (int i = 0; curr_path != NULL; i++)
-  {
-    printf("%d\t:%s\n", i, curr_path);
-    curr_path = get_path();
-  }
-
   cmd_free(cmdline);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,6 @@ int main()
     current_arg = get_arg(cmdline);
     executable = current_arg;
 
-    // FIXME: This shit broken af :/
     printf("Executable: %s\n", executable);
     for (int i = 0; current_arg != NULL; i++)
     {

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include "cmd.h"
 #include "path.h"
@@ -12,7 +13,7 @@
 int main()
 {
   Commandline *cmdline = cmd_init();
-  char *executable, *current_arg;
+  char *executable, *current_arg, *path_dir = NULL;
 
   if (cmdline == NULL)
   {
@@ -33,6 +34,11 @@ int main()
     current_arg = get_arg(cmdline);
     executable = current_arg;
 
+    if (executable == NULL)
+    {
+      continue;
+    }
+
     printf("Executable: %s\n", executable);
     for (int i = 0; current_arg != NULL; i++)
     {
@@ -45,6 +51,23 @@ int main()
 
       printf("\t%-3d: %s\n", i, current_arg);
     }
+
+    printf("Searching $PATH for `%s`\n", executable);
+
+    do
+    {
+      path_dir = get_path();
+      if (path_dir == NULL)
+        break;
+
+      printf("\t%s\n", path_dir);
+    } while (path_dir != NULL);
+
+    if (errno)
+    {
+      perror("error while running");
+    }
+
   } while (1);
 
   cmd_free(cmdline);

--- a/src/main.c
+++ b/src/main.c
@@ -1,12 +1,8 @@
-// Configuration
-// ------------------
-// Input Buffer Length
-#define IBUF_LEN 256
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
 
+#include "config.h"
 #include "cmd.h"
 #include "path.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,8 +17,7 @@ int main()
     exit(EXIT_FAILURE);
   }
 
-    errno = 0;
-    do
+  do
   {
     errno = 0;
     printf("> ");

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@
 int main()
 {
   Commandline *cmdline = cmd_init();
-  char *executable, *current_arg, *path_dir = NULL;
+  char *executable = NULL;
 
   if (cmdline == NULL)
   {
@@ -28,38 +28,9 @@ int main()
       break;
     }
 
-    current_arg = get_arg(cmdline);
-    executable = current_arg;
-
-    if (executable == NULL)
-    {
-      continue;
-    }
-
-    printf("Executable: %s\n", executable);
-    for (int i = 0; current_arg != NULL; i++)
-    {
-      current_arg = get_arg(cmdline);
-
-      // Sometimes this becomes NULL
-      // as this loop is executing
-      if (current_arg == NULL)
-        break;
-
-      printf("\t%-3d: %s\n", i, current_arg);
-    }
-
-    printf("Searching $PATH for `%s`\n", executable);
-
-    do
-    {
-      path_dir = get_path();
-      if (path_dir == NULL)
-        break;
-
-      printf("\t%s\n", path_dir);
-    } while (path_dir != NULL);
-
+    process_arg(cmdline, &executable);
+    if (executable != NULL)
+      executable = search_executable(executable);
     if (errno)
     {
       perror("error while running");

--- a/src/path.c
+++ b/src/path.c
@@ -6,33 +6,82 @@
 #include <string.h>
 #include <stdio.h>
 
-char *get_path()
+size_t count_seps(char *path)
 {
-  static char *env_path = NULL;
-  static char *current_path = NULL;
-
-  if (!env_path)
+  // Count the number of separators in the $PATH variable
+  size_t sep_count = 0;
+  for (char *path_char = path; *path_char; path_char++)
   {
-    char *path = getenv("PATH");
-    if (!path)
-      return NULL;
-
-    env_path = strdup(path);
-    if (!env_path)
-      return NULL;
-
-    current_path = strtok(env_path, ":");
+    if (*path_char == ':')
+      sep_count++;
   }
-  else
+
+  return sep_count;
+}
+
+void copy_paths(char *path, char **paths)
+{
+  char *current_path = strtok(path, ":");
+  size_t indx;
+  for (indx = 0; current_path; indx++)
   {
+    paths[indx] = current_path;
     current_path = strtok(NULL, ":");
   }
 
-  if (!current_path)
+  paths[indx] = NULL;
+}
+
+char **init_path(void)
+{
+  char *path = getenv("PATH");
+  if (!path)
+    return NULL;
+
+  char *path_dup = strdup(path);
+  if (!path_dup)
+    return NULL;
+
+  size_t sep_count = count_seps(path_dup);
+  char **paths = (char **)malloc((sep_count + 1) * sizeof(char *));
+  if (!paths)
   {
-    free(env_path);
-    env_path = NULL;
+    free(path_dup);
+    return NULL;
   }
 
-  return current_path;
+  copy_paths(path_dup, paths);
+  free(path_dup);
+  return paths;
 }
+
+// char *get_path()
+// {
+//   static char *env_path = NULL;
+//   static char *current_path = NULL;
+
+//   if (!env_path)
+//   {
+//     char *path = getenv("PATH");
+//     if (!path)
+//       return NULL;
+
+//     env_path = strdup(path);
+//     if (!env_path)
+//       return NULL;
+
+//     current_path = strtok(env_path, ":");
+//   }
+//   else
+//   {
+//     current_path = strtok(NULL, ":");
+//   }
+
+//   if (!current_path)
+//   {
+//     free(env_path);
+//     env_path = NULL;
+//   }
+
+//   return current_path;
+// }

--- a/src/path.c
+++ b/src/path.c
@@ -4,7 +4,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 size_t count_seps(char *path)
 {

--- a/src/path.c
+++ b/src/path.c
@@ -4,16 +4,35 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 char *get_path()
 {
-  static char *path = NULL;
+  static char *env_path = NULL;
+  static char *current_path = NULL;
 
-  if (!path)
+  if (!env_path)
   {
-    path = getenv("PATH");
-    return strtok(path, ":");
+    char *path = getenv("PATH");
+    if (!path)
+      return NULL;
+
+    env_path = strdup(path);
+    if (!env_path)
+      return NULL;
+
+    current_path = strtok(env_path, ":");
+  }
+  else
+  {
+    current_path = strtok(NULL, ":");
   }
 
-  return strtok(NULL, ":");
+  if (!current_path)
+  {
+    free(env_path);
+    env_path = NULL;
+  }
+
+  return current_path;
 }


### PR DESCRIPTION
## Summary by Sourcery

Implement `$PATH` variable search to locate executables. The program now reads commands from the user, parses them into arguments, and searches for the executable in the directories specified in the `$PATH` environment variable.

Enhancements:
- Improve command line parsing and argument extraction.
- Enhance error handling during command execution.
- Refactor path handling to correctly parse and iterate through `$PATH` directories.
- Add a basic interactive loop to continuously read and execute commands.
- Improve memory management by freeing allocated memory when it's no longer needed.
- Add error handling for when the program is unable to read from stdin.
- Clear the token after every line is read to prevent issues with subsequent commands.
- Return an exit code from `read_line` to indicate whether the program should exit.
- Print the executable name and its arguments to the console.
- Print the directories in `$PATH` as they are searched.