### PR TITLE
added cmake configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Makefile
 .vscode/*
 msh
 .vscode/*.json
+
+/include/config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(msh VERSION 0.0.1)
 
 # set(IBUF_LEN "Input Buffer Length, in bytes" 256)
-set(IBUF_LEN 256 CACHE STRING "Input buffer length")
+set(MSH_IBUF_LEN 256 CACHE STRING "Input buffer length")
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include)
 # Configure the header file
@@ -15,3 +15,13 @@ configure_file(
 file(GLOB SOURCES src/*.c)
 include_directories(include/)
 add_executable(${PROJECT_NAME} ${SOURCES})
+
+message(STATUS "Project Configuration:")
+get_cmake_property(_variableNames CACHE_VARIABLES)
+foreach (_variableName ${_variableNames})
+    get_property(_help CACHE ${_variableName} PROPERTY HELPSTRING)
+    get_property(_type CACHE ${_variableName} PROPERTY TYPE)
+    if(NOT _type STREQUAL "INTERNAL" AND _variableName MATCHES "^MSH")  # Exclude internal variables
+        message(STATUS "  ${_variableName} = ${${_variableName}} (${_help})")
+    endif()
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,16 @@ cmake_minimum_required(VERSION 3.20)
 
 project(msh VERSION 0.0.1)
 
+# set(IBUF_LEN "Input Buffer Length, in bytes" 256)
+set(IBUF_LEN 256 CACHE STRING "Input buffer length")
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include)
+# Configure the header file
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/config.h.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/config.h
+)
+
 file(GLOB SOURCES src/*.c)
 include_directories(include/)
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,17 @@ cmake_minimum_required(VERSION 3.20)
 
 project(msh VERSION 0.0.1)
 
-# set(IBUF_LEN "Input Buffer Length, in bytes" 256)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(DEBUG ON)
+else()
+    set(DEBUG OFF)
+endif()
+
+# Project Configuration
 set(MSH_IBUF_LEN 256 CACHE STRING "Input buffer length")
+set(DEBUG ${DEBUG} CACHE BOOL "Debug mode")
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include)
-# Configure the header file
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/config.h.in
   ${CMAKE_CURRENT_SOURCE_DIR}/include/config.h

--- a/include/config.h
+++ b/include/config.h
@@ -1,4 +1,0 @@
-// Configuration
-// ------------------
-// Input Buffer Length
-#define IBUF_LEN 256

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -11,4 +11,4 @@
 #define GREETING PROJECT_NAME " v" PROJECT_VERSION "\n"
 
 // Input Buffer Length
-#define IBUF_LEN @IBUF_LEN@
+#define IBUF_LEN @MSH_IBUF_LEN@

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -1,0 +1,14 @@
+// Configuration
+// ------------------
+// Configuration by editing this file is highly
+// discouraged. Please use `cmake` to configure
+// values for msh
+
+#pragma once
+
+#define PROJECT_VERSION "@CMAKE_PROJECT_VERSION@"
+#define PROJECT_NAME "@PROJECT_NAME@"
+#define GREETING PROJECT_NAME " v" PROJECT_VERSION "\n"
+
+// Input Buffer Length
+#define IBUF_LEN @IBUF_LEN@

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -6,9 +6,14 @@
 
 #pragma once
 
+// Project metadata
 #define PROJECT_VERSION "@CMAKE_PROJECT_VERSION@"
 #define PROJECT_NAME "@PROJECT_NAME@"
 #define GREETING PROJECT_NAME " v" PROJECT_VERSION "\n"
 
 // Input Buffer Length
 #define IBUF_LEN @MSH_IBUF_LEN@
+
+// Whether or not `cmake` will make a debug
+// executable
+#cmakedefine DEBUG

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -128,3 +128,4 @@ void process_arg(Commandline *cmdline, char **executable)
 
     printf("\t%-3d: %s\n", i, current_arg);
   }
+}

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@ int main()
     exit(EXIT_FAILURE);
   }
 
+  printf(GREETING);
   do
   {
     errno = 0;


### PR DESCRIPTION
## Summary by Sourcery

Adds a CMake configuration to the project, including options for setting the input buffer length and debug mode. Also adds a greeting message to the main function.

Build:
- Introduces a CMake build system for the project.
- Adds options to configure the input buffer length and debug mode via CMake.
- Generates a configuration header file from CMake settings.