### PR TITLE
Integration with `libreadline`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,1 @@
 build/
-CMakeFiles
-CMakeCache.txt
-*.cmake
-Makefile
-*.exe
-.vscode/*
-msh
-.vscode/*.json

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "name": "Linux",
+      "includePath": [
+        "${workspaceFolder}/**"
+      ],
+      "defines": [],
+      "cStandard": "c17",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "linux-clang-x64"
+    }
+  ],
+  "version": 4
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,6 @@ include_directories(include/)
 add_executable(${PROJECT_NAME} ${SOURCES})
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${READLINE_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${READLINE_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${READLINE_LIBRARIES} history)
 target_compile_options(${PROJECT_NAME} PRIVATE ${READLINE_CFLAGS_OTHER})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ else()
 endif()
 
 # Project Configuration
-set(MSH_IBUF_LEN 256 CACHE STRING "Input buffer length")
 set(DEBUG ${DEBUG} CACHE BOOL "Debug mode")
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.20)
 
 project(msh VERSION 0.0.1)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(READLINE REQUIRED readline)
+
 file(GLOB SOURCES src/*.c)
 include_directories(include/)
 add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${READLINE_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${READLINE_LIBRARIES})
+target_compile_options(${PROJECT_NAME} PRIVATE ${READLINE_CFLAGS_OTHER})
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 # Project Configuration
 set(DEBUG ${DEBUG} CACHE BOOL "Debug mode")
+set(MSH_HISTFILE "~/.msh_history" CACHE STRING "Path to msh's history file")
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include)
 configure_file(

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -11,9 +11,6 @@
 #define PROJECT_NAME "@PROJECT_NAME@"
 #define GREETING PROJECT_NAME " v" PROJECT_VERSION "\n"
 
-// Input Buffer Length
-#define IBUF_LEN @MSH_IBUF_LEN@
-
 // Whether or not `cmake` will make a debug
 // executable
 #cmakedefine DEBUG

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -14,3 +14,6 @@
 // Whether or not `cmake` will make a debug
 // executable
 #cmakedefine DEBUG
+
+// Path to the histfile
+#define HISTFILE "@MSH_HISTFILE@"

--- a/include/history.h
+++ b/include/history.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void begin_history();
+void end_history();
+void add_entry(char *line);

--- a/include/path.h
+++ b/include/path.h
@@ -1,1 +1,1 @@
-char **init_path(void);
+char **init_path(char *path_dup);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -23,6 +23,7 @@ struct cmd_t
   char *buf;
   char *tok;
   char **bin_dirs;
+  char *path_buf;
 };
 
 Commandline *cmd_init()
@@ -38,7 +39,7 @@ Commandline *cmd_init()
   args->buf = NULL;
   args->tok = NULL;
 
-  args->bin_dirs = init_path();
+  args->bin_dirs = init_path(args->path_buf);
 
   using_history();
   if (read_history(".msh_history") && errno != ENOENT)
@@ -54,6 +55,7 @@ void cmd_free(Commandline *cmdline)
   if (cmdline->buf)
     free(cmdline->buf);
 
+  free(cmdline->path_buf);
   free(cmdline->bin_dirs);
   free(cmdline);
 }
@@ -63,6 +65,7 @@ int read_line(Commandline *cmdline)
   if (cmdline->buf)
   {
     free(cmdline->buf);
+    cmdline->buf = NULL;
   }
 
   if (cmdline->tok)

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -25,6 +25,20 @@ struct cmd_t
   char *path_buf;
 };
 
+void clear_input(Commandline *cmdline)
+{
+  if (cmdline->tok)
+  {
+    free(cmdline->tok);
+    cmdline->tok = NULL;
+  }
+  if (cmdline->buf)
+  {
+    free(cmdline->buf);
+    cmdline->buf = NULL;
+  }
+}
+
 Commandline *cmd_init()
 {
   Commandline *args = (Commandline *)malloc(sizeof(Commandline));
@@ -49,10 +63,7 @@ Commandline *cmd_init()
 
 void cmd_free(Commandline *cmdline)
 {
-  if (cmdline->tok)
-    free(cmdline->tok);
-  if (cmdline->buf)
-    free(cmdline->buf);
+  clear_input(cmdline);
 
   free(cmdline->path_buf);
   free(cmdline->bin_dirs);
@@ -64,19 +75,10 @@ void cmd_free(Commandline *cmdline)
 
 int read_line(Commandline *cmdline)
 {
-  if (cmdline->buf)
-  {
-    free(cmdline->buf);
-    cmdline->buf = NULL;
-  }
-
-  if (cmdline->tok)
-  {
-    // After every line is read, whatever remains
-    // inside `tok` should be cleared
-    free(cmdline->tok);
-    cmdline->tok = NULL;
-  }
+  // After every line is read, whatever remains
+  // inside `tok` and `buf` should be cleared
+  // and reset
+  clear_input(cmdline);
 
   cmdline->buf = readline("> ");
   if (cmdline->buf && *cmdline->buf)

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -6,6 +6,10 @@
 #define IBUF_LEN 32
 #endif
 
+#ifndef HISTFILE
+#define HISTFILE ".msh_history"
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -42,7 +46,7 @@ Commandline *cmd_init()
   args->bin_dirs = init_path(args->path_buf);
 
   using_history();
-  if (read_history(".msh_history") && errno != ENOENT)
+  if (read_history(HISTFILE) && errno != ENOENT)
     perror("unable to fetch history");
 
   return args;
@@ -58,6 +62,9 @@ void cmd_free(Commandline *cmdline)
   free(cmdline->path_buf);
   free(cmdline->bin_dirs);
   free(cmdline);
+
+  if (write_history(HISTFILE))
+    perror("unable to save history");
 }
 
 int read_line(Commandline *cmdline)
@@ -77,15 +84,13 @@ int read_line(Commandline *cmdline)
   }
 
   cmdline->buf = readline("> ");
-  if (cmdline->buf)
+  if (cmdline->buf && *cmdline->buf)
   {
-    char *history = strdup(cmdline->buf);
-
-    add_history(history);
-
-    free(history);
-    return 0;
+    add_history(cmdline->buf);
   }
+
+  if (cmdline->buf)
+    return 0;
   return 1;
 }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2,18 +2,14 @@
 
 #define IBUF_DENY " "
 
-#ifndef HISTFILE
-#define HISTFILE ".msh_history"
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 
 #include <readline/readline.h>
-#include <readline/history.h>
 
+#include "history.h"
 #include "tokenize.h"
 #include "path.h"
 
@@ -54,10 +50,6 @@ Commandline *cmd_init()
 
   args->bin_dirs = init_path(args->path_buf);
 
-  using_history();
-  if (read_history(HISTFILE) && errno != ENOENT)
-    perror("unable to fetch history");
-
   return args;
 }
 
@@ -69,8 +61,7 @@ void cmd_free(Commandline *cmdline)
   free(cmdline->bin_dirs);
   free(cmdline);
 
-  if (write_history(HISTFILE))
-    perror("unable to save history");
+  end_history();
 }
 
 int read_line(Commandline *cmdline)
@@ -81,10 +72,8 @@ int read_line(Commandline *cmdline)
   clear_input(cmdline);
 
   cmdline->buf = readline("> ");
-  if (cmdline->buf && *cmdline->buf)
-  {
-    add_history(cmdline->buf);
-  }
+
+  add_entry(cmdline->buf);
 
   if (cmdline->buf)
     return 0;

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2,10 +2,6 @@
 
 #define IBUF_DENY " "
 
-#ifndef IBUF_LEN
-#define IBUF_LEN 32
-#endif
-
 #ifndef HISTFILE
 #define HISTFILE ".msh_history"
 #endif

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -17,7 +17,6 @@
 
 #include <readline/readline.h>
 #include <readline/history.h>
-// #include <readline/
 
 #include "tokenize.h"
 #include "path.h"

--- a/src/history.c
+++ b/src/history.c
@@ -1,0 +1,30 @@
+#include "history.h"
+
+#include <errno.h>
+
+#include <readline/history.h>
+
+#ifndef HISTFILE
+#define HISTFILE ".msh_history"
+#endif
+
+void begin_history()
+{
+  using_history();
+  if (read_history(HISTFILE) && errno != ENOENT)
+    perror("unable to fetch history");
+}
+
+void end_history()
+{
+  if (write_history(HISTFILE))
+    perror("unable to save history");
+}
+
+void add_entry(char *line)
+{
+  if (line && *line)
+  {
+    add_history(line);
+  }
+}

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,6 @@ int main()
   do
   {
     errno = 0;
-    printf("> ");
 
     if (read_line(cmdline))
     {

--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,6 @@ int main()
 
   if (cmdline == NULL)
   {
-    cmd_free(cmdline);
     perror("failed to initialize tokenizer");
     exit(EXIT_FAILURE);
   }

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@ int main()
 
   if (cmdline == NULL)
   {
+    cmd_free(cmdline);
     perror("failed to initialize tokenizer");
     exit(EXIT_FAILURE);
   }

--- a/src/path.c
+++ b/src/path.c
@@ -1,7 +1,5 @@
 #include "path.h"
 
-#define _XOPEN_SOURCE 500
-
 #include <stdlib.h>
 #include <string.h>
 
@@ -53,34 +51,3 @@ char **init_path(void)
   free(path_dup);
   return paths;
 }
-
-// char *get_path()
-// {
-//   static char *env_path = NULL;
-//   static char *current_path = NULL;
-
-//   if (!env_path)
-//   {
-//     char *path = getenv("PATH");
-//     if (!path)
-//       return NULL;
-
-//     env_path = strdup(path);
-//     if (!env_path)
-//       return NULL;
-
-//     current_path = strtok(env_path, ":");
-//   }
-//   else
-//   {
-//     current_path = strtok(NULL, ":");
-//   }
-
-//   if (!current_path)
-//   {
-//     free(env_path);
-//     env_path = NULL;
-//   }
-
-//   return current_path;
-// }

--- a/src/path.c
+++ b/src/path.c
@@ -29,24 +29,24 @@ void copy_paths(char *path, char **paths)
   paths[indx] = NULL;
 }
 
-char **init_path(char *path_dup)
+char **init_path(char *full_path)
 {
   char *path = getenv("PATH");
   if (!path)
     return NULL;
 
-  path_dup = strdup(path);
-  if (!path_dup)
+  full_path = strdup(path);
+  if (!full_path)
     return NULL;
 
-  size_t sep_count = count_seps(path_dup);
+  size_t sep_count = count_seps(full_path);
   char **paths = (char **)malloc((sep_count + 1) * sizeof(char *));
   if (!paths)
   {
-    free(path_dup);
+    free(full_path);
     return NULL;
   }
 
-  copy_paths(path_dup, paths);
+  copy_paths(full_path, paths);
   return paths;
 }

--- a/src/path.c
+++ b/src/path.c
@@ -29,13 +29,13 @@ void copy_paths(char *path, char **paths)
   paths[indx] = NULL;
 }
 
-char **init_path(void)
+char **init_path(char *path_dup)
 {
   char *path = getenv("PATH");
   if (!path)
     return NULL;
 
-  char *path_dup = strdup(path);
+  path_dup = strdup(path);
   if (!path_dup)
     return NULL;
 
@@ -48,6 +48,5 @@ char **init_path(void)
   }
 
   copy_paths(path_dup, paths);
-  free(path_dup);
   return paths;
 }


### PR DESCRIPTION
idk how this should work with windows systems but welp idrc :clown_face: :+1:

This PR adds MSH's first dependency, `libreadline`, using it in place of `fgets(3)` and deprecating the `IBUF_LEN`

## Summary by Sourcery

Integrate `libreadline` to replace `fgets(3)` for reading user input, providing enhanced line editing and history features. Update the build system to link against `libreadline` and `history` libraries.

New Features:
- Introduce line editing and history capabilities using `libreadline`.
- Add support for persisting command history to a file named `.msh_history`.
- The shell now uses the `readline` library to handle user input, replacing the previous `fgets` approach.